### PR TITLE
[Feature] Init build.gradle productization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Framework Technical specifications available at: https://raw.githubusercontent.c
 - [Use cases](#use-cases)
 - [Additional Documentation](#documentation)
 
-
+#### Usage
+To start using this library, declare the following dependency in your Maven or Gradle build file: ```group: 'com.iab.gdpr', name: 'consent-string-sdk-java', version:'<your target version>'```
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,21 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
+
+group = 'com.iab.gdpr'
+version = '1.0.0-SNAPSHOT'
+
+description = """A Java implementation of the IAB Consent String spec."""
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 repositories {
     mavenCentral()
 }
 
- dependencies {
-        testCompile (
-            "junit:junit:4.11",
-        )
-    }
+dependencies {
+    testCompile (
+        "junit:junit:4.11",
+    )
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'consent-string-sdk-java'


### PR DESCRIPTION
The purpose of this PR is to start applying some necessary productization to the build config, so that this library can be safely and easily used in external projects soon. Changes:
* configure project name in settings.gradle to adhere to Maven artifact naming conventions (see https://maven.apache.org/guides/mini/guide-naming-conventions.html)
* set groupId to com.iab.gdpr
* init versioning scheme, by setting version to 1.0.0-SNAPSHOT
* set source/target compatibility to Java 8. Important point to discuss: is supporting Java versions older than 1.8 required? 
* refactor dependencies formatting
* add tiny entry to the README file, describing how to start using the library

Also, once the library starts being published to a public Maven repository (see the critical issue #6), some versioning and branching strategies should be established, documented and enforced. This is discussed in #7.