### PR TITLE
Replace binary search with iteration through array due to lack of sorting constraint

### DIFF
--- a/src/main/java/com/iab/gdpr/ConsentStringParser.java
+++ b/src/main/java/com/iab/gdpr/ConsentStringParser.java
@@ -235,24 +235,8 @@ public class ConsentStringParser {
 	}
 
 	private boolean findVendorIdInRange(int vendorId) {
-		int limit = rangeEntries.size();
-		if (limit == 0) {
-			return false;
-		}
-		int index = limit / 2;
-		while (index >= 0 && index < limit) {
-			RangeEntry entry = rangeEntries.get(index);
-			if (entry.containsVendorId(vendorId)) {
-				return true;
-			}
-			if (index == 0 || index == limit - 1) {
-				return false;
-			}
-			if (entry.idIsGreaterThanMax(vendorId)) {
-				index = (index + ((limit - index) / 2));
-			} else {
-				index = index / 2;
-			}
+	  for (RangeEntry rangeEntry : rangeEntries) {
+	  	if (rangeEntry.containsVendorId(vendorId)) return true;
 		}
 		return false;
 	}
@@ -277,33 +261,20 @@ public class ConsentStringParser {
 		/**
 		 * This class corresponds to the RangeEntry field given in the consent string specification.
 		 */
-		private final List<Integer> vendorIds = new ArrayList<Integer>();
 		private final int maxVendorId;
 		private final int minVendorId;
 
 		public RangeEntry(int vendorId) {
-			vendorIds.add(vendorId);
 			this.maxVendorId = this.minVendorId = vendorId;
 		}
 
 		public RangeEntry(int startId, int endId) {
 			this.maxVendorId = endId;
 			this.minVendorId = startId;
-			for (; startId <= endId; startId++) {
-				vendorIds.add(startId);
-			}
 		}
 
 		public boolean containsVendorId(int vendorId) {
-			return vendorIds.indexOf(vendorId) >= 0;
-		}
-
-		public boolean idIsGreaterThanMax(int vendorId) {
-			return vendorId > maxVendorId;
-		}
-
-		public boolean isIsLessThanMin(int vendorId) {
-			return vendorId < minVendorId;
+			return vendorId >= minVendorId && vendorId <= maxVendorId;
 		}
 	}
 


### PR DESCRIPTION
This PR makes the following changes:

1. When searching for a vendor ID in the collection of `rangeEntries`, iterate through all the items instead of binary searching through them. Based on the [IAB spec](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md), it's not clear that we can assume the RangeEntries in the cookie string will always be sorted. E.g. it may be possible for a cookie's range entries section to look like `(5 - 10), (63 - 80), (11 - 15)`, in which case binary search wouldn't work. Alternatively, there could be some validation logic to ensure that the RangeEntries in the cookie string are sorted as they are parsed (rejecting the cookie as invalid otherwise).

2. Remove the private member `vendorIds` from the `RangeEntry` struct. It is only referenced in `containsVendorId`, but that method can be implemented in constant time by checking to see if the supplied vendor ID falls within the range specified by `minVendorId` and `maxVendorId`. 