### PR TITLE
Add a method to get allowed purposed bits as an integer

### DIFF
--- a/src/main/java/com/iab/gdpr/VendorConsent.java
+++ b/src/main/java/com/iab/gdpr/VendorConsent.java
@@ -15,6 +15,9 @@ import com.iab.gdpr.exception.VendorConsentException;
 import com.iab.gdpr.exception.VendorConsentParseException;
 import com.iab.gdpr.util.ConsentStringParser;
 
+import static com.iab.gdpr.GdprConstants.PURPOSES_OFFSET;
+import static com.iab.gdpr.GdprConstants.PURPOSES_SIZE;
+
 /**
  * This class implements a builder and a factory method for the IAB consent as specified in
  * https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/
@@ -111,9 +114,9 @@ public class VendorConsent {
         int i = 0;
         for (boolean purpose : allowedPurposes) {
             if (purpose) {
-                bits.setBit(GdprConstants.PURPOSES_OFFSET + i++);
+                bits.setBit(PURPOSES_OFFSET + i++);
             } else {
-                bits.unsetBit(GdprConstants.PURPOSES_OFFSET + i++);
+                bits.unsetBit(PURPOSES_OFFSET + i++);
             }
         }
 
@@ -284,6 +287,14 @@ public class VendorConsent {
 
     /**
      *
+     * @return an integer equivalent of allowed purpose id bits according to this consent string
+     */
+    public int getAllowedPurposesBits() {
+        return bits.getInt(PURPOSES_OFFSET, PURPOSES_SIZE);
+    }
+
+    /**
+     *
      * @return the vendor list version which was used in creating this consent string
      */
     public int getVendorListVersion() {
@@ -424,7 +435,7 @@ public class VendorConsent {
         private int vendorListVersion;
         private int maxVendorId;
         private int vendorEncodingType;
-        private List<Boolean> allowedPurposes = new ArrayList<>(GdprConstants.PURPOSES_SIZE);
+        private List<Boolean> allowedPurposes = new ArrayList<>(PURPOSES_SIZE);
         // only used when bitfield is enabled
         private List<Integer> vendorsBitField;
         // only used when range entry is enabled
@@ -515,7 +526,7 @@ public class VendorConsent {
          */
         public Builder withAllowedPurposes(List<Integer> allowedPurposes) {
             this.integerPurposes = allowedPurposes;
-            for (int i = 0; i < GdprConstants.PURPOSES_SIZE; i++) {
+            for (int i = 0; i < PURPOSES_SIZE; i++) {
                 this.allowedPurposes.add(false);
             }
             for (int purpose : allowedPurposes) {

--- a/src/test/java/com/iab/gdpr/VendorConsentTest.java
+++ b/src/test/java/com/iab/gdpr/VendorConsentTest.java
@@ -68,6 +68,7 @@ public class VendorConsentTest {
         assertThat(consent.getConsentRecordCreated(), Matchers.is(Instant.ofEpochMilli(14924661858L * 100)));
         assertThat(consent.getConsentRecordLastUpdated(), Matchers.is(Instant.ofEpochMilli(15240021858L * 100)));
         assertThat(consent.getAllowedPurposes().size(), Matchers.is(5));
+        assertThat(consent.getAllowedPurposesBits(), Matchers.is(6291482));
 
         assertTrue(consent.isPurposeAllowed(2));
         assertFalse(consent.isPurposeAllowed(1));
@@ -94,6 +95,7 @@ public class VendorConsentTest {
         assertThat(consent.getConsentRecordCreated(), Matchers.is(Instant.ofEpochMilli(14924661858L * 100)));
         assertThat(consent.getConsentRecordLastUpdated(), Matchers.is(Instant.ofEpochMilli(15240021858L * 100)));
         assertThat(consent.getAllowedPurposes().size(), Matchers.is(8));
+        assertThat(consent.getAllowedPurposesBits(), Matchers.is(2000001));
 
         assertTrue(consent.isPurposeAllowed(4));
         assertFalse(consent.isPurposeAllowed(1));
@@ -208,30 +210,4 @@ public class VendorConsentTest {
         assertFalse(consent.isVendorAllowed(3));
         assertTrue(consent.isVendorAllowed(27));
     }
-    
-    @Test
-    public void testLongRangeEntry() {
-        String consentString = "BOOMzbgOOQww_AtABAFRAb-AAAsvOA3gACAAkABgArgBaAF0AMAA1gBuAH8AQQBSgCoAL8AYQBigDIAM0AaABpgDYAOYAdgA8AB6gD4AQoAiABFQCMAI6ASABIgCTAEqAJeATIBQQCiAKSAU4BVQCtAK-AWYBaQC2ALcAXMAvAC-gGAAYcAxQDGAGQAMsAZsA0ADTAGqANcAbMA4ADjAHKAOiAdQB1gDtgHgAeMA9AD2AHzAP4BAACBAEEAIbAREBEgCKQEXARhZeYA";
-        VendorConsent consent = VendorConsent.fromBase64String(consentString);
-        assertThat(consent.getCmpId(), Matchers.is(45));
-        assertThat(consent.getCmpVersion(), Matchers.is(1));
-        assertThat(consent.getConsentLanguage(), Matchers.is("FR"));
-        assertThat(consent.getConsentRecordCreated(), Matchers.is(Instant.ofEpochMilli(15270622944L * 100)));
-        assertThat(consent.getConsentRecordLastUpdated(), Matchers.is(Instant.ofEpochMilli(15271660607L * 100)));
-        assertThat(consent.getAllowedPurposes().size(), Matchers.is(5));    assertTrue(consent.isPurposeAllowed(1));
-        assertTrue(consent.isPurposeAllowed(2));
-        assertTrue(consent.isPurposeAllowed(3));
-        assertTrue(consent.isPurposeAllowed(4));
-        assertTrue(consent.isPurposeAllowed(5));
-        assertFalse(consent.isPurposeAllowed(6));
-        assertFalse(consent.isPurposeAllowed(25));
-        assertFalse(consent.isPurposeAllowed(0));
-        assertTrue(consent.isVendorAllowed(1));
-        assertFalse(consent.isVendorAllowed(5));
-        assertTrue(consent.isVendorAllowed(45));
-        assertFalse(consent.isVendorAllowed(47));
-        assertFalse(consent.isVendorAllowed(146));
-        assertTrue(consent.isVendorAllowed(147));
-        assertThat(consent.getConsentString(), Matchers.is(consentString));
-    }    
 }


### PR DESCRIPTION
Hi,

we'd like to store the allowed purposes (as I imagine others will want to as well). The most optimal form to do that seems to be an integer. Therefore the proposed changes add a method to return the allowed purposes as a single integer.

Not too sure about the naming and importing the constants, so happy to change the code to match your style if needed.