### PR TITLE
Count SingleOrRange bits when allocating bits for vendore range entries

### DIFF
--- a/src/main/java/com/iab/gdpr/VendorConsent.java
+++ b/src/main/java/com/iab/gdpr/VendorConsent.java
@@ -80,7 +80,7 @@ public class VendorConsent {
         this.integerPurposes = builder.integerPurposes;
 
         if (this.vendorEncodingType == GdprConstants.VENDOR_ENCODING_RANGE) {
-            int rangeEntrySize = 0;
+            int rangeEntrySize = rangeEntries.size(); // one bit SingleOrRange flag per entry
             for (RangeEntry entry : rangeEntries) {
                 if (entry.endVendorId == entry.startVendorId) {
                     rangeEntrySize += GdprConstants.VENDOR_ID_SIZE;

--- a/src/test/java/com/iab/gdpr/VendorConsentTest.java
+++ b/src/test/java/com/iab/gdpr/VendorConsentTest.java
@@ -69,6 +69,37 @@ public class VendorConsentTest {
     }
 
     @Test
+    public void testLongRangeEntry() {
+        String consentString = "BOOMzbgOOQww_AtABAFRAb-AAAsvOA3gACAAkABgArgBaAF0AMAA1gBuAH8AQQBSgCoAL8AYQBigDIAM0AaABpgDYAOYAdgA8AB6gD4AQoAiABFQCMAI6ASABIgCTAEqAJeATIBQQCiAKSAU4BVQCtAK-AWYBaQC2ALcAXMAvAC-gGAAYcAxQDGAGQAMsAZsA0ADTAGqANcAbMA4ADjAHKAOiAdQB1gDtgHgAeMA9AD2AHzAP4BAACBAEEAIbAREBEgCKQEXARhZeYA";
+
+        VendorConsent consent = VendorConsent.fromBase64String(consentString);
+
+        assertThat(consent.getCmpId(), Matchers.is(45));
+        assertThat(consent.getCmpVersion(), Matchers.is(1));
+        assertThat(consent.getConsentLanguage(), Matchers.is("FR"));
+        assertThat(consent.getConsentRecordCreated(), Matchers.is(Instant.ofEpochMilli(15270622944L * 100)));
+        assertThat(consent.getConsentRecordLastUpdated(), Matchers.is(Instant.ofEpochMilli(15271660607L * 100)));
+        assertThat(consent.getAllowedPurposes().size(), Matchers.is(5));
+
+        assertTrue(consent.isPurposeAllowed(1));
+        assertTrue(consent.isPurposeAllowed(2));
+        assertTrue(consent.isPurposeAllowed(3));
+        assertTrue(consent.isPurposeAllowed(4));
+        assertTrue(consent.isPurposeAllowed(5));
+        assertFalse(consent.isPurposeAllowed(6));
+        assertFalse(consent.isPurposeAllowed(25));
+        assertFalse(consent.isPurposeAllowed(0));
+        assertTrue(consent.isVendorAllowed(1));
+        assertFalse(consent.isVendorAllowed(5));
+        assertTrue(consent.isVendorAllowed(45));
+        assertFalse(consent.isVendorAllowed(47));
+        assertFalse(consent.isVendorAllowed(146));
+        assertTrue(consent.isVendorAllowed(147));
+
+        assertThat(consent.getConsentString(), Matchers.is(consentString));
+    }
+
+    @Test
     public void testCreationOfConsentString() {
         String consentString = "BN5lERiOMYEdiAKAWXEND1HoSBE6CAFAApAMgBkIDIgM0AgOJxAnQA";
 


### PR DESCRIPTION
Hi again,

we've noticed that some valid consent strings would not get parsed. The reason being that when a range entry is submitted - `rangeEntrySize` calculation forgets to count `SingleOrRange` bits.

The old test works only because there are 5 entries in the list and when `bitsFit` pads the size to bytes it adds 6.