### PR TITLE
Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ build/*
 *.swp
 gradle-app.setting
 !gradle-wrapper.jar
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+/out/

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,16 @@ apply plugin: 'idea'
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
+
+group = 'com.iab.gdpr'
+version = '2.0.0-SNAPSHOT'
+
+description = """A Java implementation of the IAB Consent String spec."""
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     testCompile(

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'consent-string-sdk-java'

--- a/src/main/java/com/iab/gdpr/Purpose.java
+++ b/src/main/java/com/iab/gdpr/Purpose.java
@@ -1,0 +1,59 @@
+package com.iab.gdpr;
+
+/**
+ * 
+ * Enumeration of currently defined purposes by IAB
+ *
+ *  @see <a href="https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework">https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework</a>
+ *
+ */
+public enum Purpose {
+
+    STORAGE_AND_ACCESS(1), // The storage of information, or access to information that is already stored, on user device such as accessing advertising identifiers
+                           // and/or other device identifiers, and/or using cookies or similar technologies.
+
+    PERSONALIZATION(2),    // The collection and processing of information about user of a site to subsequently personalize advertising for them in other contexts,
+                           // i.e. on other sites or apps, over time. Typically, the content of the site or app is used to make inferences about user interests, which inform future selections.
+
+    AD_SELECTION(3),       // The collection of information and combination with previously collected information, to select and deliver advertisements and to measure the delivery
+                           // and effectiveness of such advertisements. This includes using previously collected information about user interests to select ads, processing data about
+                           // what advertisements were shown, how often they were shown, when and where they were shown, and whether they took any action related to the advertisement,
+                           // including for example clicking an ad or making a purchase.
+
+    CONTENT_DELIVERY(4),   // The collection of information, and combination with previously collected information, to select and deliver content and to measure the delivery and
+                           // effectiveness of such content. This includes using previously collected information about user interests to select content, processing data about
+                           // what content was shown, how often or how long it was shown, when and where it was shown, and whether they took any action related to the content,
+                           // including for example clicking on content.
+
+    MEASUREMENT(5),        // The collection of information about user use of content, and combination with previously collected information, used to measure, understand,
+                           // and report on user usage of content.
+
+    UNDEFINED(-1),         // Purpose ID that is currently not defined
+    ;
+
+    private final int id;
+
+    Purpose(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Map numeric purpose ID to Enum
+     * @param purposeId purpose ID
+     * @return Enum value of purpose
+     */
+    public static Purpose valueOf(int purposeId) {
+        switch(purposeId) {
+            case 1: return STORAGE_AND_ACCESS;
+            case 2: return PERSONALIZATION;
+            case 3: return AD_SELECTION;
+            case 4: return CONTENT_DELIVERY;
+            case 5: return MEASUREMENT;
+            default: return UNDEFINED;
+        }
+    }
+}

--- a/src/main/java/com/iab/gdpr/VendorConsent.java
+++ b/src/main/java/com/iab/gdpr/VendorConsent.java
@@ -25,6 +25,7 @@ import static com.iab.gdpr.GdprConstants.PURPOSES_SIZE;
  * 20specification%20v1.0a.pdf
  *
  */
+@Deprecated
 public class VendorConsent {
     private static Decoder decoder = Base64.getUrlDecoder();
     // As per the GDPR framework guidelines padding should be ommitted

--- a/src/main/java/com/iab/gdpr/consent/VendorConsent.java
+++ b/src/main/java/com/iab/gdpr/consent/VendorConsent.java
@@ -1,5 +1,7 @@
 package com.iab.gdpr.consent;
 
+import com.iab.gdpr.Purpose;
+
 import java.time.Instant;
 import java.util.Set;
 
@@ -63,7 +65,13 @@ public interface VendorConsent {
      *
      * @return the set of purpose id's which are permitted according to this consent string
      */
-    Set<Integer> getAllowedPurposes();
+    Set<Integer> getAllowedPurposeIds();
+
+    /**
+     *
+     * @return the set of allowed purposes which are permitted according to this consent string
+     */
+    Set<Purpose> getAllowedPurposes();
 
     /**
      *
@@ -83,6 +91,13 @@ public interface VendorConsent {
      * @return true if purpose is allowed in this consent, false otherwise
      */
     boolean isPurposeAllowed(int purposeId);
+
+    /**
+     * Check whether specified purpose is allowed
+     * @param purpose purpose to check
+     * @return true if purpose is allowed in this consent, false otherwise
+     */
+    boolean isPurposeAllowed(Purpose purpose);
 
     /**
      * Check whether vendor with specified ID is allowd

--- a/src/main/java/com/iab/gdpr/consent/VendorConsent.java
+++ b/src/main/java/com/iab/gdpr/consent/VendorConsent.java
@@ -1,0 +1,100 @@
+package com.iab.gdpr.consent;
+
+import java.time.Instant;
+import java.util.Set;
+
+/**
+ * Representation of the values in the vendor consent string.
+ *
+ * Combination of {@link VendorConsent#isPurposeAllowed(int)} and {@link VendorConsent#isVendorAllowed(int)} methods
+ * fully describes user's consent for particular action by a particular vendor
+ *
+ */
+public interface VendorConsent {
+
+    /**
+     *
+     * @return the version of consent string format
+     */
+    int getVersion();
+
+    /**
+     * @return the {@link Instant} at which the consent string was created
+     */
+    Instant getConsentRecordCreated();
+
+    /**
+     *
+     * @return the {@link Instant} at which consent string was last updated
+     */
+    Instant getConsentRecordLastUpdated();
+
+    /**
+     *
+     * @return the Consent Manager Provider ID that last updated the consent string
+     */
+    int getCmpId();
+
+    /**
+     *
+     * @return the Consent Manager Provider version
+     */
+    int getCmpVersion();
+
+    /**
+     *
+     * @return the screen number in the CMP where consent was given
+     */
+    int getConsentScreen();
+
+    /**
+     *
+     * @return the two-letter ISO639-1 language code that CMP asked for consent in
+     */
+    String getConsentLanguage();
+
+    /**
+     *
+     * @return version of vendor list used in most recent consent string update.
+     */
+    int getVendorListVersion();
+
+    /**
+     *
+     * @return the set of purpose id's which are permitted according to this consent string
+     */
+    Set<Integer> getAllowedPurposes();
+
+    /**
+     *
+     * @return an integer equivalent of allowed purpose id bits according to this consent string
+     */
+    int getAllowedPurposesBits();
+
+    /**
+     *
+     * @return the maximum VendorId for which consent values are given.
+     */
+    int getMaxVendorId();
+
+    /**
+     * Check whether purpose with specified ID is allowed
+     * @param purposeId purpose ID
+     * @return true if purpose is allowed in this consent, false otherwise
+     */
+    boolean isPurposeAllowed(int purposeId);
+
+    /**
+     * Check whether vendor with specified ID is allowd
+     * @param vendorId vendor ID
+     * @return a boolean describing if a user has consented to a particular vendor
+     */
+    boolean isVendorAllowed(int vendorId);
+
+    /**
+     *
+     * @return the value of this consent as byte array
+     */
+    byte[] toByteArray();
+
+}

--- a/src/main/java/com/iab/gdpr/consent/VendorConsentDecoder.java
+++ b/src/main/java/com/iab/gdpr/consent/VendorConsentDecoder.java
@@ -1,0 +1,50 @@
+package com.iab.gdpr.consent;
+
+import com.iab.gdpr.Bits;
+import com.iab.gdpr.consent.implementation.v1.ByteBufferBackedVendorConsent;
+
+import java.util.Base64;
+
+import static com.iab.gdpr.GdprConstants.VERSION_BIT_OFFSET;
+import static com.iab.gdpr.GdprConstants.VERSION_BIT_SIZE;
+
+/**
+ * {@link VendorConsent} decoder from Base64 string. Right now only version 1 is know, but eventually
+ * this can be extended to support new versions
+ */
+public class VendorConsentDecoder {
+
+    private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
+
+    public static VendorConsent fromBase64String(String consentString) {
+        if (isNullOrEmpty(consentString))
+            throw new IllegalArgumentException("Null or empty consent string passed as an argument");
+
+        final Bits bits = new Bits(BASE64_DECODER.decode(consentString));
+        final int version = getVersion(bits);
+        switch (version) {
+            case 1:
+                return new ByteBufferBackedVendorConsent(bits);
+            default:
+                throw new IllegalStateException("Unsupported version: " + version);
+        }
+    }
+
+    /**
+     * Get the version field from bitmap
+     * @param bits bitmap
+     * @return a version number
+     */
+    private static int getVersion(Bits bits) {
+        return bits.getInt(VERSION_BIT_OFFSET, VERSION_BIT_SIZE);
+    }
+
+    /**
+     * Utility method to check whether string is empty or null
+     * @param string value to check
+     * @return a boolean value of the check
+     */
+    private static boolean isNullOrEmpty(String string) {
+        return string == null || string.isEmpty();
+    }
+}

--- a/src/main/java/com/iab/gdpr/consent/VendorConsentEncoder.java
+++ b/src/main/java/com/iab/gdpr/consent/VendorConsentEncoder.java
@@ -1,0 +1,22 @@
+package com.iab.gdpr.consent;
+
+import java.util.Base64;
+
+/**
+ * Encode {@link VendorConsent} to Base64 string
+ */
+public class VendorConsentEncoder {
+
+    // As per the GDPR framework guidelines padding should be omitted
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    /**
+     * Encode vendor consent to Base64 string
+     * @param vendorConsent vendor consent
+     * @return Base64 encoded string
+     */
+    public static String toBase64String(VendorConsent vendorConsent) {
+        return ENCODER.encodeToString(vendorConsent.toByteArray());
+    }
+
+}

--- a/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
+++ b/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
@@ -1,0 +1,197 @@
+package com.iab.gdpr.consent.implementation.v1;
+
+
+import com.iab.gdpr.Bits;
+import com.iab.gdpr.consent.VendorConsent;
+import com.iab.gdpr.exception.VendorConsentParseException;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.iab.gdpr.GdprConstants.*;
+
+/**
+ * Implementation of {@link VendorConsent}. This implementation uses byte buffer (wrapped with {@link Bits})
+ * as a storage of consent string values and parses individual fields on demand.
+ *
+ * This should work well in environment where vendor consent string is decoded, couple of isPurposeAllowed()/isVendorAllowed()
+ * calls are made and then value of the consent is discarded.
+ *
+ * In the environment where decoded consent string is kept for longer time with numerous isPurposeAllowed()/isVendorAllowed()
+ * calls a different implementation may be needed that would cache results of those calls.
+ *
+ */
+public class ByteBufferBackedVendorConsent implements VendorConsent {
+    private final Bits bits;
+
+    public ByteBufferBackedVendorConsent(Bits bits) {
+        this.bits = bits;
+    }
+
+    @Override
+    public int getVersion() {
+        return bits.getInt(VERSION_BIT_OFFSET, VERSION_BIT_SIZE);
+    }
+
+    @Override
+    public Instant getConsentRecordCreated() {
+        return bits.getInstantFromEpochDeciseconds(CREATED_BIT_OFFSET, CREATED_BIT_SIZE);
+    }
+
+    @Override
+    public Instant getConsentRecordLastUpdated() {
+        return bits.getInstantFromEpochDeciseconds(UPDATED_BIT_OFFSET, UPDATED_BIT_SIZE);
+    }
+
+    @Override
+    public int getCmpId() {
+        return bits.getInt(CMP_ID_OFFSET, CMP_ID_SIZE);
+    }
+
+    @Override
+    public int getCmpVersion() {
+        return bits.getInt(CMP_VERSION_OFFSET, CMP_VERSION_SIZE);
+    }
+
+    @Override
+    public int getConsentScreen() {
+        return bits.getInt(CONSENT_SCREEN_SIZE_OFFSET, CONSENT_SCREEN_SIZE);
+    }
+
+    @Override
+    public String getConsentLanguage() {
+        return bits.getSixBitString(CONSENT_LANGUAGE_OFFSET, CONSENT_LANGUAGE_SIZE);
+    }
+
+    @Override
+    public int getVendorListVersion() {
+        return bits.getInt(VENDOR_LIST_VERSION_OFFSET, VENDOR_LIST_VERSION_SIZE);
+    }
+
+    @Override
+    public Set<Integer> getAllowedPurposes() {
+        final Set<Integer> allowedPurposes = new HashSet<>();
+        for (int i = PURPOSES_OFFSET; i < PURPOSES_OFFSET + PURPOSES_SIZE; i++) {
+            if (bits.getBit(i)) {
+                allowedPurposes.add(i - PURPOSES_OFFSET + 1);
+            }
+        }
+        return allowedPurposes;
+    }
+
+    @Override
+    public int getAllowedPurposesBits() {
+        return bits.getInt(PURPOSES_OFFSET, PURPOSES_SIZE);
+    }
+
+    @Override
+    public int getMaxVendorId() {
+        return bits.getInt(MAX_VENDOR_ID_OFFSET, MAX_VENDOR_ID_SIZE);
+    }
+
+    @Override
+    public boolean isPurposeAllowed(int purposeId) {
+        if (purposeId < 1) return false;
+        return getAllowedPurposes().contains(purposeId);
+    }
+
+    @Override
+    public boolean isVendorAllowed(int vendorId) {
+        final int maxVendorId = getMaxVendorId();
+        if (vendorId < 0 || vendorId > maxVendorId) return false;
+
+        if (encodingType() == VENDOR_ENCODING_RANGE) {
+            final boolean defaultConsent = bits.getBit(DEFAULT_CONSENT_OFFSET);
+            final boolean present = isVendorPresentInRange(vendorId);
+            return present != defaultConsent;
+        } else {
+            return bits.getBit(VENDOR_BITFIELD_OFFSET + vendorId - 1);
+        }
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return bits.toByteArray();
+    }
+
+    /**
+     *
+     * @return the encoding type - 0=BitField 1=Range
+     */
+    private int encodingType() {
+        return bits.getInt(ENCODING_TYPE_OFFSET, ENCODING_TYPE_SIZE);
+    }
+
+    /**
+     * Check whether specified vendor ID is present in the range section of the bits. This assumes that
+     * encoding type was already checked and is VENDOR_ENCODING_RANGE
+     * @param vendorId vendor ID to check
+     * @return boolean value of vendor ID presence
+     */
+    private boolean isVendorPresentInRange(int vendorId) {
+        final int numEntries = bits.getInt(NUM_ENTRIES_OFFSET, NUM_ENTRIES_SIZE);
+        final int maxVendorId = getMaxVendorId();
+        int currentOffset = RANGE_ENTRY_OFFSET;
+        for (int i = 0; i < numEntries; i++) {
+            boolean range = bits.getBit(currentOffset);
+            currentOffset++;
+            if (range) {
+                int startVendorId = bits.getInt(currentOffset, VENDOR_ID_SIZE);
+                currentOffset += VENDOR_ID_SIZE;
+                int endVendorId = bits.getInt(currentOffset, VENDOR_ID_SIZE);
+                currentOffset += VENDOR_ID_SIZE;
+
+                if (startVendorId > endVendorId || endVendorId > maxVendorId) {
+                    throw new VendorConsentParseException(
+                            "Start VendorId must not be greater than End VendorId and "
+                                    + "End VendorId must not be greater than Max Vendor Id");
+                }
+                if (vendorId >= startVendorId && vendorId <= endVendorId) return true;
+
+            } else {
+                int singleVendorId = bits.getInt(currentOffset, VENDOR_ID_SIZE);
+                currentOffset += VENDOR_ID_SIZE;
+
+                if (singleVendorId > maxVendorId) {
+                    throw new VendorConsentParseException(
+                            "VendorId in the range entries must not be greater than Max VendorId");
+                }
+
+                if (singleVendorId == vendorId) return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ByteBufferBackedVendorConsent that = (ByteBufferBackedVendorConsent) o;
+        return Arrays.equals(bits.toByteArray(), that.bits.toByteArray());
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bits.toByteArray());
+    }
+
+    @Override
+    public String toString() {
+        return "ByteBufferVendorConsent{" +
+                "Version=" + getVersion() +
+                ",Created=" + getConsentRecordCreated() +
+                ",LastUpdated=" + getConsentRecordLastUpdated() +
+                ",CmpId=" + getCmpId() +
+                ",CmpVersion=" + getCmpVersion() +
+                ",ConsentScreen=" + getConsentScreen() +
+                ",ConsentLanguage=" + getConsentLanguage() +
+                ",VendorListVersion=" + getVendorListVersion() +
+                ",PurposesAllowed=" + getAllowedPurposes() +
+                ",MaxVendorId=" + getMaxVendorId() +
+                ",EncodingType=" + encodingType() +
+                "}";
+    }
+}

--- a/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
+++ b/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
@@ -2,6 +2,7 @@ package com.iab.gdpr.consent.implementation.v1;
 
 
 import com.iab.gdpr.Bits;
+import com.iab.gdpr.Purpose;
 import com.iab.gdpr.consent.VendorConsent;
 import com.iab.gdpr.exception.VendorConsentParseException;
 
@@ -9,6 +10,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.iab.gdpr.GdprConstants.*;
 
@@ -71,7 +73,7 @@ public class ByteBufferBackedVendorConsent implements VendorConsent {
     }
 
     @Override
-    public Set<Integer> getAllowedPurposes() {
+    public Set<Integer> getAllowedPurposeIds() {
         final Set<Integer> allowedPurposes = new HashSet<>();
         for (int i = PURPOSES_OFFSET; i < PURPOSES_OFFSET + PURPOSES_SIZE; i++) {
             if (bits.getBit(i)) {
@@ -79,6 +81,11 @@ public class ByteBufferBackedVendorConsent implements VendorConsent {
             }
         }
         return allowedPurposes;
+    }
+
+    @Override
+    public Set<Purpose> getAllowedPurposes() {
+        return getAllowedPurposeIds().stream().map(Purpose::valueOf).collect(Collectors.toSet());
     }
 
     @Override
@@ -94,7 +101,12 @@ public class ByteBufferBackedVendorConsent implements VendorConsent {
     @Override
     public boolean isPurposeAllowed(int purposeId) {
         if (purposeId < 1) return false;
-        return getAllowedPurposes().contains(purposeId);
+        return getAllowedPurposeIds().contains(purposeId);
+    }
+
+    @Override
+    public boolean isPurposeAllowed(Purpose purpose) {
+        return isPurposeAllowed(purpose.getId());
     }
 
     @Override
@@ -189,7 +201,7 @@ public class ByteBufferBackedVendorConsent implements VendorConsent {
                 ",ConsentScreen=" + getConsentScreen() +
                 ",ConsentLanguage=" + getConsentLanguage() +
                 ",VendorListVersion=" + getVendorListVersion() +
-                ",PurposesAllowed=" + getAllowedPurposes() +
+                ",PurposesAllowed=" + getAllowedPurposeIds() +
                 ",MaxVendorId=" + getMaxVendorId() +
                 ",EncodingType=" + encodingType() +
                 "}";

--- a/src/main/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilder.java
+++ b/src/main/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilder.java
@@ -2,11 +2,13 @@ package com.iab.gdpr.consent.implementation.v1;
 
 import com.iab.gdpr.Bits;
 import com.iab.gdpr.GdprConstants;
+import com.iab.gdpr.Purpose;
 import com.iab.gdpr.consent.range.RangeEntry;
 import com.iab.gdpr.consent.VendorConsent;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.iab.gdpr.GdprConstants.*;
 
@@ -102,17 +104,30 @@ public class VendorConsentBuilder {
     }
 
     /**
-     * With allowed puposes
+     * With allowed purpose IDs
+     * @param allowedPurposeIds set of allowed purposes
+     * @return builder
+     */
+    public VendorConsentBuilder withAllowedPurposeIds(Set<Integer> allowedPurposeIds) {
+        // Validate
+        Objects.requireNonNull(allowedPurposeIds, "Argument allowedPurposeIds is null");
+        final boolean invalidPurposeIdFound = allowedPurposeIds.stream().anyMatch(purposeId -> purposeId < 0 || purposeId > PURPOSES_SIZE);
+        if (invalidPurposeIdFound) throw new IllegalArgumentException("Invalid purpose ID found");
+
+        this.allowedPurposes = allowedPurposeIds;
+        return this;
+    }
+
+    /**
+     * With allowed purposes
      * @param allowedPurposes set of allowed purposes
      * @return builder
      */
-    public VendorConsentBuilder withAllowedPurposes(Set<Integer> allowedPurposes) {
+    public VendorConsentBuilder withAllowedPurposes(Set<Purpose> allowedPurposes) {
         // Validate
         Objects.requireNonNull(allowedPurposes, "Argument allowedPurposes is null");
-        final boolean invalidPurposeIdFound = allowedPurposes.stream().anyMatch(purposeId -> purposeId < 0 || purposeId > PURPOSES_SIZE);
-        if (invalidPurposeIdFound) throw new IllegalArgumentException("Invalid purpose ID found");
 
-        this.allowedPurposes = allowedPurposes;
+        this.allowedPurposes = allowedPurposes.stream().map(Purpose::getId).collect(Collectors.toSet());
         return this;
     }
 

--- a/src/main/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilder.java
+++ b/src/main/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilder.java
@@ -1,0 +1,257 @@
+package com.iab.gdpr.consent.implementation.v1;
+
+import com.iab.gdpr.Bits;
+import com.iab.gdpr.GdprConstants;
+import com.iab.gdpr.consent.range.RangeEntry;
+import com.iab.gdpr.consent.VendorConsent;
+
+import java.time.Instant;
+import java.util.*;
+
+import static com.iab.gdpr.GdprConstants.*;
+
+/**
+ * Builder for version 1 of vendor consent
+ */
+public class VendorConsentBuilder {
+
+    private static final int VERSION = 1;
+
+    private Instant consentRecordCreated;
+    private Instant consentRecordLastUpdated;
+    private int cmpID;
+    private int cmpVersion;
+    private int consentScreenID;
+    private String consentLanguage;
+    private int vendorListVersion;
+    private int maxVendorId;
+    private int vendorEncodingType;
+    private Set<Integer> allowedPurposes = new HashSet<>(PURPOSES_SIZE);
+    private Set<Integer> vendorsBitField; // used when bit field encoding is used
+    private List<RangeEntry> rangeEntries; // used when range entry encoding is used
+    private boolean defaultConsent;
+
+    /**
+     * With creation date
+     * @param consentRecordCreated Epoch deciseconds when record was created
+     * @return builder
+     */
+    public VendorConsentBuilder withConsentRecordCreatedOn(Instant consentRecordCreated) {
+        this.consentRecordCreated = consentRecordCreated;
+        return this;
+    }
+
+    /**
+     * With update date
+     * @param consentRecordLastUpdated Epoch deciseconds when consent string was last updated
+     * @return builder
+     */
+    public VendorConsentBuilder withConsentRecordLastUpdatedOn(Instant consentRecordLastUpdated) {
+        this.consentRecordLastUpdated = consentRecordLastUpdated;
+        return this;
+    }
+
+    /**
+     * With CMP id
+     * @param cmpID Consent Manager Provider ID that last updated the consent string
+     * @return builder
+     */
+    public VendorConsentBuilder withCmpID(int cmpID) {
+        this.cmpID = cmpID;
+        return this;
+    }
+
+    /**
+     * With CMP version
+     * @param cmpVersion Consent Manager Provider version
+     * @return builder
+     */
+    public VendorConsentBuilder withCmpVersion(int cmpVersion) {
+        this.cmpVersion = cmpVersion;
+        return this;
+    }
+
+    /**
+     * With consent screen ID
+     * @param consentScreenID Screen number in the CMP where consent was given
+     * @return builder
+     */
+    public VendorConsentBuilder withConsentScreenID(int consentScreenID) {
+        this.consentScreenID = consentScreenID;
+        return this;
+    }
+
+    /**
+     * With consent language
+     * @param consentLanguage Two-letter ISO639-1 language code that CMP asked for consent in
+     * @return builder
+     */
+    public VendorConsentBuilder withConsentLanguage(String consentLanguage) {
+        this.consentLanguage = consentLanguage;
+        return this;
+    }
+
+    /**
+     * With vendor list version
+     * @param vendorListVersion Version of vendor list used in most recent consent string update
+     * @return builder
+     */
+    public VendorConsentBuilder withVendorListVersion(int vendorListVersion) {
+        this.vendorListVersion = vendorListVersion;
+        return this;
+    }
+
+    /**
+     * With allowed puposes
+     * @param allowedPurposes set of allowed purposes
+     * @return builder
+     */
+    public VendorConsentBuilder withAllowedPurposes(Set<Integer> allowedPurposes) {
+        // Validate
+        Objects.requireNonNull(allowedPurposes, "Argument allowedPurposes is null");
+        final boolean invalidPurposeIdFound = allowedPurposes.stream().anyMatch(purposeId -> purposeId < 0 || purposeId > PURPOSES_SIZE);
+        if (invalidPurposeIdFound) throw new IllegalArgumentException("Invalid purpose ID found");
+
+        this.allowedPurposes = allowedPurposes;
+        return this;
+    }
+
+    /**
+     * With max vendor ID
+     * @param maxVendorId The maximum VendorId for which consent values are given.
+     * @return builder
+     */
+    public VendorConsentBuilder withMaxVendorId(int maxVendorId) {
+        this.maxVendorId = maxVendorId;
+        return this;
+    }
+
+    /**
+     * With vendor encoding type
+     * @param vendorEncodingType 0=BitField 1=Range
+     * @return builder
+     */
+    public VendorConsentBuilder withVendorEncodingType(int vendorEncodingType) {
+        if (vendorEncodingType < 0 || vendorEncodingType > 1)
+            throw new IllegalArgumentException("Illegal value for argument vendorEncodingType:" + vendorEncodingType);
+
+        this.vendorEncodingType = vendorEncodingType;
+        return this;
+    }
+
+    /**
+     * With bit field entries
+     * @param bitFieldEntries set of VendorIds for which the vendors have consent
+     * @return builder
+     */
+    public VendorConsentBuilder withBitField(Set<Integer> bitFieldEntries) {
+        this.vendorsBitField = bitFieldEntries;
+        return this;
+    }
+
+    /**
+     * With range entries
+     * @param rangeEntries List of VendorIds or a range of VendorIds for which the vendors have consent
+     * @return builder
+     */
+    public VendorConsentBuilder withRangeEntries(List<RangeEntry> rangeEntries) {
+        this.rangeEntries = rangeEntries;
+        return this;
+    }
+
+    /**
+     * With default consent
+     * @param defaultConsent Default consent for VendorIds not covered by a RangeEntry. 0=No Consent 1=Consent
+     * @return builder
+     */
+    public VendorConsentBuilder withDefaultConsent(boolean defaultConsent) {
+        this.defaultConsent = defaultConsent;
+        return this;
+    }
+
+    /**
+     * Validate supplied values and build {@link VendorConsent} object
+     * @return vendor consent object
+     */
+    public VendorConsent build() {
+
+        Objects.requireNonNull(consentRecordCreated, "consentRecordCreated must be set");
+        Objects.requireNonNull(consentRecordLastUpdated, "consentRecordLastUpdated must be set");
+        Objects.requireNonNull(consentLanguage, "consentLanguage must be set");
+
+        if (vendorListVersion <=0 )
+            throw new IllegalStateException("Invalid value for vendorListVersion:" + vendorListVersion);
+
+        if (maxVendorId <=0 )
+            throw new IllegalStateException("Invalid value for maxVendorId:" + maxVendorId);
+
+        // For range encoding, check if each range entry is valid
+        if (vendorEncodingType == VENDOR_ENCODING_RANGE) {
+            Objects.requireNonNull(rangeEntries, "Range entries must be set");
+            final boolean invalidRangeEntriesFound = rangeEntries.stream().anyMatch(rangeEntry -> !rangeEntry.valid(maxVendorId));
+            if (invalidRangeEntriesFound) throw new IllegalStateException("Invalid range entries found");
+        }
+
+        // Calculate size of bit buffer in bits
+        final int bitBufferSizeInBits;
+        if (vendorEncodingType == VENDOR_ENCODING_RANGE) {
+            final int rangeEntrySectionSize = rangeEntries.stream().mapToInt(RangeEntry::size).sum();
+            bitBufferSizeInBits = RANGE_ENTRY_OFFSET + rangeEntrySectionSize;
+        } else {
+            bitBufferSizeInBits = VENDOR_BITFIELD_OFFSET + this.maxVendorId;
+        }
+
+        // Create new bit buffer
+        final boolean bitsFit = (bitBufferSizeInBits % 8) == 0;
+        final Bits bits = new Bits(new byte[bitBufferSizeInBits / 8 + (bitsFit ? 0 : 1)]);
+
+        // Set fields in bit buffer
+        bits.setInt(VERSION_BIT_OFFSET, VERSION_BIT_SIZE, VERSION);
+        bits.setInstantToEpochDeciseconds(CREATED_BIT_OFFSET, CREATED_BIT_SIZE, consentRecordCreated);
+        bits.setInstantToEpochDeciseconds(UPDATED_BIT_OFFSET, UPDATED_BIT_SIZE, consentRecordLastUpdated);
+        bits.setInt(CMP_ID_OFFSET, CMP_ID_SIZE, this.cmpID);
+        bits.setInt(CMP_VERSION_OFFSET, CMP_VERSION_SIZE, cmpVersion);
+        bits.setInt(CONSENT_SCREEN_SIZE_OFFSET, CONSENT_SCREEN_SIZE, consentScreenID);
+        bits.setSixBitString(CONSENT_LANGUAGE_OFFSET, CONSENT_LANGUAGE_SIZE, consentLanguage);
+        bits.setInt(VENDOR_LIST_VERSION_OFFSET, VENDOR_LIST_VERSION_SIZE, vendorListVersion);
+
+        // Set purposes bits
+        for (int i = 0; i < PURPOSES_SIZE; i++) {
+            if (allowedPurposes.contains(i+1))
+                bits.setBit(PURPOSES_OFFSET + i);
+            else
+                bits.unsetBit(PURPOSES_OFFSET + i);
+        }
+
+        bits.setInt(MAX_VENDOR_ID_OFFSET, MAX_VENDOR_ID_SIZE, maxVendorId);
+        bits.setInt(ENCODING_TYPE_OFFSET, ENCODING_TYPE_SIZE, vendorEncodingType);
+
+        // Set the bit field or range sections
+        if (vendorEncodingType == VENDOR_ENCODING_RANGE) {
+            // Range encoding
+            if (defaultConsent) {
+                bits.setBit(DEFAULT_CONSENT_OFFSET);
+            } else {
+                bits.unsetBit(DEFAULT_CONSENT_OFFSET);
+            }
+            bits.setInt(NUM_ENTRIES_OFFSET, NUM_ENTRIES_SIZE, rangeEntries.size());
+
+            int currentOffset = GdprConstants.RANGE_ENTRY_OFFSET;
+
+            for (RangeEntry rangeEntry : rangeEntries) {
+                currentOffset = rangeEntry.appendTo(bits, currentOffset);
+            }
+
+        } else {
+            // Bit field encoding
+            for (int i = 0; i < maxVendorId; i++) {
+                if (vendorsBitField.contains(i+1))
+                    bits.setBit(VENDOR_BITFIELD_OFFSET+i);
+                else
+                    bits.unsetBit(VENDOR_BITFIELD_OFFSET + i);
+            }
+        }
+
+        return new ByteBufferBackedVendorConsent(bits);
+    }
+}

--- a/src/main/java/com/iab/gdpr/consent/range/RangeEntry.java
+++ b/src/main/java/com/iab/gdpr/consent/range/RangeEntry.java
@@ -1,0 +1,30 @@
+package com.iab.gdpr.consent.range;
+
+import com.iab.gdpr.Bits;
+
+/**
+ * Range entry  of the vendor consent range section. Range entry is a single or range of VendorIds
+ * whose consent value is the opposite of DefaultConsent.
+ */
+public interface RangeEntry {
+
+    /**
+     * @return Size of range entry in bits
+     */
+    int size();
+
+    /**
+     * Append this range entry to the bit buffer
+     * @param buffer bit buffer
+     * @param currentOffset current offset in the buffer
+     * @return new offset
+     */
+    int appendTo(Bits buffer, int currentOffset);
+
+    /**
+     * Check if range entry is valid for the specified max vendor id
+     * @param maxVendorId max vendor id
+     * @return true if range entry is valid, false otherwise
+     */
+    boolean valid(int maxVendorId);
+}

--- a/src/main/java/com/iab/gdpr/consent/range/SingleRangeEntry.java
+++ b/src/main/java/com/iab/gdpr/consent/range/SingleRangeEntry.java
@@ -1,0 +1,36 @@
+package com.iab.gdpr.consent.range;
+
+import com.iab.gdpr.Bits;
+
+import static com.iab.gdpr.GdprConstants.VENDOR_ID_SIZE;
+
+/**
+ * {@link RangeEntry} with single vendor ID
+ */
+public class SingleRangeEntry implements RangeEntry {
+    private final int singeVendorId;
+
+    public SingleRangeEntry(int singeVendorId) {
+        this.singeVendorId = singeVendorId;
+    }
+
+    @Override
+    public int size() {
+        // One bit for SingleOrRange flag, VENDOR_ID_SIZE for single vendor ID
+        return 1+VENDOR_ID_SIZE;
+    }
+
+    @Override
+    public int appendTo(Bits buffer, int currentOffset) {
+        int newOffset = currentOffset;
+        buffer.unsetBit(newOffset++); // 0=Single
+        buffer.setInt(newOffset, VENDOR_ID_SIZE, singeVendorId);
+        newOffset += VENDOR_ID_SIZE;
+        return newOffset;
+    }
+
+    @Override
+    public boolean valid(int maxVendorId) {
+        return singeVendorId > 0 && singeVendorId <= maxVendorId;
+    }
+}

--- a/src/main/java/com/iab/gdpr/consent/range/StartEndRangeEntry.java
+++ b/src/main/java/com/iab/gdpr/consent/range/StartEndRangeEntry.java
@@ -1,0 +1,40 @@
+package com.iab.gdpr.consent.range;
+
+import com.iab.gdpr.Bits;
+
+import static com.iab.gdpr.GdprConstants.VENDOR_ID_SIZE;
+
+/**
+ * {@link RangeEntry} with start and end vendor IDs
+ */
+public class StartEndRangeEntry implements RangeEntry{
+    private final int startVendorId;
+    private final int endVendorId;
+
+    public StartEndRangeEntry(int startVendorId, int endVendorId) {
+        this.startVendorId = startVendorId;
+        this.endVendorId = endVendorId;
+    }
+
+    @Override
+    public int size() {
+        // One bit for SingleOrRange flag, 2 * VENDOR_ID_SIZE for 2 vendor IDs
+        return 1+VENDOR_ID_SIZE * 2;
+    }
+
+    @Override
+    public int appendTo(Bits buffer, int currentOffset) {
+        int newOffset = currentOffset;
+        buffer.setBit(newOffset++); // 1=Range
+        buffer.setInt(newOffset, VENDOR_ID_SIZE, startVendorId);
+        newOffset += VENDOR_ID_SIZE;
+        buffer.setInt(newOffset, VENDOR_ID_SIZE, endVendorId);
+        newOffset += VENDOR_ID_SIZE;
+        return newOffset;
+    }
+
+    @Override
+    public boolean valid(int maxVendorId) {
+        return startVendorId > 0 && endVendorId > 0 && startVendorId < endVendorId && endVendorId <= maxVendorId;
+    }
+}

--- a/src/main/java/com/iab/gdpr/util/ConsentStringParser.java
+++ b/src/main/java/com/iab/gdpr/util/ConsentStringParser.java
@@ -43,6 +43,7 @@ import com.iab.gdpr.exception.VendorConsentParseException;
  * Draft_for_Public_Comment_Transparency%20%26%20Consent%20Framework%20-%20cookie%20and%20vendor%20list%20format%
  * 20specification%20v1.0a.pdf
  */
+@Deprecated
 public class ConsentStringParser {
     private Bits bits;
 

--- a/src/test/java/com/iab/gdpr/consent/VendorConsentDecoderTest.java
+++ b/src/test/java/com/iab/gdpr/consent/VendorConsentDecoderTest.java
@@ -1,0 +1,64 @@
+package com.iab.gdpr.consent;
+
+import com.iab.gdpr.Bits;
+import com.iab.gdpr.consent.implementation.v1.ByteBufferBackedVendorConsent;
+import org.junit.Test;
+
+import java.util.Base64;
+
+import static com.iab.gdpr.GdprConstants.VERSION_BIT_OFFSET;
+import static com.iab.gdpr.GdprConstants.VERSION_BIT_SIZE;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class VendorConsentDecoderTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullConsentString() {
+        // Given: null consent string
+        String consentString = null;
+
+        // When: decoder is called
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then IllegalArgumentException exception is thrown
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyConsentString() {
+        // Given: empty consent string
+        String consentString = "";
+
+        // When: decoder is called
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then IllegalArgumentException exception is thrown
+
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testUnknownVersion() {
+        // Given: unknown version number in consent string
+        final Bits bits = new Bits(new byte[100]);
+        bits.setInt(VERSION_BIT_OFFSET, VERSION_BIT_SIZE, 10);
+
+        // When: decoder is called
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(Base64.getUrlEncoder().withoutPadding().encodeToString(bits.toByteArray()));
+
+        // Then IllegalStateException exception is thrown
+    }
+
+    @Test
+    public void testVersion1() {
+        // Given: version 1 consent string
+        final String consentString = "BOOlLqOOOlLqTABABAENAk-AAAAXx7_______9______9uz_Gv_r_f__3nW8_39P3g_7_O3_7m_-zzV48_lrQV1yPAUCgA";
+
+        // When: decoder is called
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then: v1 ByteBufferVendorConsent is returned
+        assertThat(vendorConsent.getClass(),is(ByteBufferBackedVendorConsent.class));
+
+    }
+
+}

--- a/src/test/java/com/iab/gdpr/consent/VendorConsentEncoderTest.java
+++ b/src/test/java/com/iab/gdpr/consent/VendorConsentEncoderTest.java
@@ -1,0 +1,40 @@
+package com.iab.gdpr.consent;
+
+import com.iab.gdpr.consent.implementation.v1.ByteBufferBackedVendorConsent;
+import com.iab.gdpr.util.Utils;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.*;
+
+public class VendorConsentEncoderTest {
+
+    @Test
+    public void testEncode() {
+        // Given: vendor consent binary string
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000000000100000"                     +  // Max vendor ID
+                "0"                                    +  // Bit field encoding
+                "10000000000000000000000010000100"        // Vendor bits in bit field
+                ;
+
+        // And: ByteBufferBackedVendorConsent constructed from binary string
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // When: encode is called
+        final String base64String = VendorConsentEncoder.toBase64String(vendorConsent);
+
+
+        // Then: encoded string is returned
+        assertThat(vendorConsent.getAllowedPurposesBits(),is(notNullValue()));
+    }
+}

--- a/src/test/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsentTest.java
+++ b/src/test/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsentTest.java
@@ -1,0 +1,501 @@
+package com.iab.gdpr.consent.implementation.v1;
+
+import com.iab.gdpr.consent.VendorConsent;
+import com.iab.gdpr.consent.VendorConsentDecoder;
+import com.iab.gdpr.exception.VendorConsentParseException;
+import com.iab.gdpr.util.Utils;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class ByteBufferBackedVendorConsentTest {
+
+    @Test
+    public void testVersion() {
+        // Given: version field set to 3
+        final String binaryString = "000011" + "000000000000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct version is returned
+        assertThat(vendorConsent.getVersion(),is(3));
+    }
+
+    @Test
+    public void testgetConsentRecordCreated() {
+        // Given: created date of Monday, June 4, 2018 12:00:00 AM, epoch = 1528070400
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +   // Created
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct created timestamp is returned
+        assertThat(vendorConsent.getConsentRecordCreated(),is(LocalDateTime.of(2018,6,4,0,0,0).toInstant(ZoneOffset.UTC)));
+    }
+
+    @Test
+    public void testgetConsentRecordLastUpdated() {
+        // Given: updated date of Monday, June 4, 2018 12:00:00 AM, epoch = 1528070400
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +   // Created
+                "001110001110110011010000101000000000" +   // Updated
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct updated timestamp is returned
+        assertThat(vendorConsent.getConsentRecordLastUpdated(),is(LocalDateTime.of(2018,6,4,0,0,0).toInstant(ZoneOffset.UTC)));
+    }
+
+    @Test
+    public void testgetCmpId() {
+        // Given: CMP ID of 15
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct cmp ID is returned
+        assertThat(vendorConsent.getCmpId(),is(15));
+    }
+
+    @Test
+    public void testgetCmpVersion() {
+        // Given: CMP version of 5
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct cmp version is returned
+        assertThat(vendorConsent.getCmpVersion(),is(5));
+    }
+
+    @Test
+    public void testgetConsentScreen() {
+        // Given: content screen ID of 18
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct content screen ID is returned
+        assertThat(vendorConsent.getConsentScreen(),is(18));
+    }
+
+    @Test
+    public void testgetConsentLanguage() {
+        // Given: language code of EN
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct language code is returned
+        assertThat(vendorConsent.getConsentLanguage(),is("EN"));
+    }
+
+    @Test
+    public void testgetVendorListVersion() {
+        // Given: vendor list version of 150
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // vendor list version
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct vendor list version is returned
+        assertThat(vendorConsent.getVendorListVersion(),is(150));
+    }
+
+    @Test
+    public void testgetAllowedPurposes() {
+        // Given: allowed purposes of 1,2,3,4,5,15,24
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct allowed versions are returned
+        assertThat(vendorConsent.getAllowedPurposes(),is(new HashSet<>(Arrays.asList(1,2,3,4,5,15,24))));
+        assertThat(vendorConsent.getAllowedPurposesBits(),is(16253441));
+        assertTrue(vendorConsent.isPurposeAllowed(1));
+        assertTrue(vendorConsent.isPurposeAllowed(2));
+        assertTrue(vendorConsent.isPurposeAllowed(3));
+        assertTrue(vendorConsent.isPurposeAllowed(4));
+        assertTrue(vendorConsent.isPurposeAllowed(5));
+        assertTrue(vendorConsent.isPurposeAllowed(15));
+        assertTrue(vendorConsent.isPurposeAllowed(24));
+    }
+
+    @Test
+    public void testgetMaxVendorId() {
+        // Given: max vendor ID of 382
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000000101111110"                     +  // Max vendor ID
+                "0000";
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct max vendor ID is returned
+        assertThat(vendorConsent.getMaxVendorId(),is(382));
+    }
+
+    @Test
+    public void testBitFieldEncoding() {
+        // Given: vendors 1,25 and 30 in bit field, with max vendor of of 32
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000000000100000"                     +  // Max vendor ID
+                "0"                                    +  // Bit field encoding
+                "10000000000000000000000010000100"        // Vendor bits in bit field
+                ;
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct vendor IDs are allowed
+        assertTrue(vendorConsent.isVendorAllowed(1));
+        assertTrue(vendorConsent.isVendorAllowed(25));
+        assertTrue(vendorConsent.isVendorAllowed(30));
+
+        assertFalse(vendorConsent.isVendorAllowed(2));
+        assertFalse(vendorConsent.isVendorAllowed(3));
+        assertFalse(vendorConsent.isVendorAllowed(31));
+        assertFalse(vendorConsent.isVendorAllowed(32));
+    }
+
+    @Test
+    public void testRangeEncodingDefaultFalse() {
+        // Given: vendors 1-25 and 30 with consent, with max vendor IF of 32
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000000000100000"                     +  // Max vendor ID
+                "1"                                    +  // Range encoding
+                "0"                                    +  // Default 0=No Consent
+                "000000000010"                         +  // Number of entries = 2
+                "1"                                    +  // First entry range = 1
+                "0000000000000001"                     +  // First entry from = 1
+                "0000000000011001"                     +  // First entry to = 25
+                "0"                                    +  // Second entry single = 0
+                "0000000000011110"                        // Second entry value = 30
+                ;
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct vendor IDs are allowed
+        assertTrue(vendorConsent.isVendorAllowed(1));
+        assertTrue(vendorConsent.isVendorAllowed(10));
+        assertTrue(vendorConsent.isVendorAllowed(25));
+        assertTrue(vendorConsent.isVendorAllowed(30));
+
+        assertFalse(vendorConsent.isVendorAllowed(26));
+        assertFalse(vendorConsent.isVendorAllowed(28));
+        assertFalse(vendorConsent.isVendorAllowed(31));
+        assertFalse(vendorConsent.isVendorAllowed(32));
+    }
+
+    @Test
+    public void testRangeEncodingDefaultTrue() {
+        // Given: vendors 1 and 25-30 without consent, with max vendor IF of 32
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000000000100000"                     +  // Max vendor ID
+                "1"                                    +  // Range encoding
+                "1"                                    +  // Default 1=Consent
+                "000000000010"                         +  // Number of entries = 2
+                "0"                                    +  // First entry single = 0
+                "0000000000000001"                     +  // First entry value = 1
+                "1"                                    +  // Second entry range = 1
+                "0000000000011001"                     +  // Second entry from = 25
+                "0000000000011110"                        // Second entry to = 30
+                ;
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // Then: correct vendor IDs are allowed
+        assertFalse(vendorConsent.isVendorAllowed(1));
+        assertFalse(vendorConsent.isVendorAllowed(25));
+        assertFalse(vendorConsent.isVendorAllowed(27));
+        assertFalse(vendorConsent.isVendorAllowed(30));
+
+        assertTrue(vendorConsent.isVendorAllowed(2));
+        assertTrue(vendorConsent.isVendorAllowed(15));
+        assertTrue(vendorConsent.isVendorAllowed(31));
+        assertTrue(vendorConsent.isVendorAllowed(32));
+    }
+
+    @Test(expected = VendorConsentParseException.class)
+    public void testInvalidVendorId1() {
+        // Given: invalid vendor ID in range
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000000000100000"                     +  // Max vendor ID
+                "1"                                    +  // Range encoding
+                "1"                                    +  // Default 1=Consent
+                "000000000010"                         +  // Number of entries = 2
+                "0"                                    +  // First entry single = 0
+                "0000000000000001"                     +  // First entry value = 1
+                "1"                                    +  // Second entry range = 1
+                "0000000000101000"                     +  // Second entry from = 40 - INVALID
+                "0000000000011110"                        // Second entry to = 30
+                ;
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // And: vendor check is performed
+        assertTrue(vendorConsent.isVendorAllowed(32));
+
+        // Then: exception is raised
+    }
+
+    @Test(expected = VendorConsentParseException.class)
+    public void testInvalidVendorId2() {
+        // Given: invalid vendor ID in range
+        final String binaryString = "000011" + // Version
+                "001110001110110011010000101000000000" +  // Created
+                "001110001110110011010000101000000000" +  // Updated
+                "000000001111"                         +  // CMP ID
+                "000000000101"                         +  // CMP version
+                "010010"                               +  // Content screen ID
+                "000100001101"                         +  // Language code
+                "000010010110"                         +  // Vendor list version
+                "111110000000001000000001"             +  // Allowed purposes bitmap
+                "0000000000100000"                     +  // Max vendor ID
+                "1"                                    +  // Range encoding
+                "1"                                    +  // Default 1=Consent
+                "000000000010"                         +  // Number of entries = 2
+                "0"                                    +  // First entry single = 0
+                "0000000000101000"                     +  // First entry value = 40 - INVALID
+                "1"                                    +  // Second entry range = 1
+                "0000000000011001"                     +  // Second entry from = 25
+                "0000000000011110"                        // Second entry to = 30
+                ;
+
+        // When: object is constructed
+        ByteBufferBackedVendorConsent vendorConsent = new ByteBufferBackedVendorConsent(Utils.fromBinaryString(binaryString));
+
+        // And: vendor check is performed
+        assertTrue(vendorConsent.isVendorAllowed(32));
+
+        // Then: exception is raised
+    }
+
+    /*
+        Below are tests for encoded strings from previous version of the code
+     */
+
+
+    @Test
+    public void testRealString1() {
+        // Given: known vendor consent string
+        final String consentString = "BOOlLqOOOlLqTABABAENAk-AAAAXx7_______9______9uz_Gv_r_f__3nW8_39P3g_7_O3_7m_-zzV48_lrQV1yPAUCgA";
+
+        // When: vendor consent is constructed
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then: values match expectation
+        assertEquals(380, vendorConsent.getMaxVendorId());
+        assertTrue(vendorConsent.isVendorAllowed(380));
+        assertFalse(vendorConsent.isVendorAllowed(379));
+    }
+
+    @Test
+    public void testRealString2() {
+        // Given: known vendor consent string
+        final String consentString = "BN5lERiOMYEdiAOAWeFRAAYAAaAAptQ";
+
+        // When: vendor consent is constructed
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then: values match expectation
+        assertThat(vendorConsent.getCmpId(), is(14));
+        assertThat(vendorConsent.getCmpVersion(), is(22));
+        assertThat(vendorConsent.getConsentLanguage(), is("FR"));
+        assertThat(vendorConsent.getConsentRecordCreated(), is(Instant.ofEpochMilli(14924661858L * 100)));
+        assertThat(vendorConsent.getConsentRecordLastUpdated(), is(Instant.ofEpochMilli(15240021858L * 100)));
+        assertThat(vendorConsent.getAllowedPurposes().size(), is(5));
+        assertThat(vendorConsent.getAllowedPurposesBits(), is(6291482));
+
+        assertTrue(vendorConsent.isPurposeAllowed(2));
+        assertFalse(vendorConsent.isPurposeAllowed(1));
+        assertTrue(vendorConsent.isPurposeAllowed(21));
+        assertTrue(vendorConsent.isVendorAllowed(1));
+        assertTrue(vendorConsent.isVendorAllowed(5));
+        assertTrue(vendorConsent.isVendorAllowed(7));
+        assertTrue(vendorConsent.isVendorAllowed(9));
+        assertFalse(vendorConsent.isVendorAllowed(0));
+        assertFalse(vendorConsent.isVendorAllowed(10));
+    }
+
+    @Test
+    public void testRealString3() {
+        // Given: known vendor consent string
+        final String consentString = "BN5lERiOMYEdiAKAWXEND1HoSBE6CAFAApAMgBkIDIgM0AgOJxAnQA";
+
+        // When: vendor consent is constructed
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then: values match expectation
+        assertThat(vendorConsent.getCmpId(), is(10));
+        assertThat(vendorConsent.getCmpVersion(), is(22));
+        assertThat(vendorConsent.getConsentLanguage(), is("EN"));
+        assertThat(vendorConsent.getConsentRecordCreated(), is(Instant.ofEpochMilli(14924661858L * 100)));
+        assertThat(vendorConsent.getConsentRecordLastUpdated(), is(Instant.ofEpochMilli(15240021858L * 100)));
+        assertThat(vendorConsent.getAllowedPurposes().size(), is(8));
+        assertThat(vendorConsent.getAllowedPurposesBits(), is(2000001));
+
+        assertTrue(vendorConsent.isPurposeAllowed(4));
+        assertFalse(vendorConsent.isPurposeAllowed(1));
+        assertTrue(vendorConsent.isPurposeAllowed(24));
+        assertFalse(vendorConsent.isPurposeAllowed(25));
+        assertFalse(vendorConsent.isPurposeAllowed(0));
+        assertFalse(vendorConsent.isVendorAllowed(1));
+        assertFalse(vendorConsent.isVendorAllowed(3));
+        assertTrue(vendorConsent.isVendorAllowed(225));
+        assertTrue(vendorConsent.isVendorAllowed(5000));
+        assertTrue(vendorConsent.isVendorAllowed(515));
+        assertFalse(vendorConsent.isVendorAllowed(0));
+        assertFalse(vendorConsent.isVendorAllowed(411));
+        assertFalse(vendorConsent.isVendorAllowed(3244));
+    }
+
+    @Test
+    public void testRealString4() {
+        // Given: known vendor consent string
+        final String consentString = "BOOMzbgOOQww_AtABAFRAb-AAAsvOA3gACAAkABgArgBaAF0AMAA1gBuAH8AQQBSgCoAL8AYQBigDIAM0AaABpgDYAOYAdgA8AB6gD4AQoAiABFQCMAI6ASABIgCTAEqAJeATIBQQCiAKSAU4BVQCtAK-AWYBaQC2ALcAXMAvAC-gGAAYcAxQDGAGQAMsAZsA0ADTAGqANcAbMA4ADjAHKAOiAdQB1gDtgHgAeMA9AD2AHzAP4BAACBAEEAIbAREBEgCKQEXARhZeYA";
+
+        // When: vendor consent is constructed
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then: values match expectation
+        assertThat(vendorConsent.getCmpId(), is(45));
+        assertThat(vendorConsent.getCmpVersion(), is(1));
+        assertThat(vendorConsent.getConsentLanguage(), is("FR"));
+        assertThat(vendorConsent.getConsentRecordCreated(), is(Instant.ofEpochMilli(15270622944L * 100)));
+        assertThat(vendorConsent.getConsentRecordLastUpdated(), is(Instant.ofEpochMilli(15271660607L * 100)));
+        assertThat(vendorConsent.getAllowedPurposes().size(), is(5));
+
+        assertTrue(vendorConsent.isPurposeAllowed(1));
+        assertTrue(vendorConsent.isPurposeAllowed(2));
+        assertTrue(vendorConsent.isPurposeAllowed(3));
+        assertTrue(vendorConsent.isPurposeAllowed(4));
+        assertTrue(vendorConsent.isPurposeAllowed(5));
+        assertFalse(vendorConsent.isPurposeAllowed(6));
+        assertFalse(vendorConsent.isPurposeAllowed(25));
+        assertFalse(vendorConsent.isPurposeAllowed(0));
+        assertTrue(vendorConsent.isVendorAllowed(1));
+        assertFalse(vendorConsent.isVendorAllowed(5));
+        assertTrue(vendorConsent.isVendorAllowed(45));
+        assertFalse(vendorConsent.isVendorAllowed(47));
+        assertFalse(vendorConsent.isVendorAllowed(146));
+        assertTrue(vendorConsent.isVendorAllowed(147));
+    }
+
+    @Test
+    public void testRealString5() {
+        // Given: known vendor consent string
+        final String consentString = "BONZt-1ONZt-1AHABBENAO-AAAAHCAEAASABmADYAOAAeA";
+
+        // When: vendor vendorConsent is constructed
+        final VendorConsent vendorConsent = VendorConsentDecoder.fromBase64String(consentString);
+
+        // Then: values match expectation
+        assertTrue(vendorConsent.isPurposeAllowed(1));
+        assertTrue(vendorConsent.isPurposeAllowed(3));
+        assertTrue(vendorConsent.isVendorAllowed(28));
+        assertFalse(vendorConsent.isVendorAllowed(1));
+        assertFalse(vendorConsent.isVendorAllowed(3));
+        assertTrue(vendorConsent.isVendorAllowed(27));
+    }
+
+}

--- a/src/test/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilderTest.java
+++ b/src/test/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilderTest.java
@@ -1,0 +1,227 @@
+package com.iab.gdpr.consent.implementation.v1;
+
+import com.iab.gdpr.consent.range.RangeEntry;
+import com.iab.gdpr.consent.range.SingleRangeEntry;
+import com.iab.gdpr.consent.range.StartEndRangeEntry;
+import com.iab.gdpr.consent.VendorConsent;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class VendorConsentBuilderTest {
+
+    private Instant now;
+
+    @Before
+    public void setUp() {
+        now = LocalDateTime.now().withNano(0).toInstant(ZoneOffset.UTC);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPurpose() {
+        // Given: invalid purpose ID in the set
+        final Set<Integer> allowedPurposes = new HashSet<>(Arrays.asList(1, 2, 3, 99));
+
+        // When: passing set to the builder
+        new VendorConsentBuilder().withAllowedPurposes(allowedPurposes);
+
+        // Then: exception is thrown
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidVendorEncodingType() {
+        // Given: invalid vendor encoding type
+        int vendorEncodingType = 3;
+
+        // When: passing vendor type to builder
+        new VendorConsentBuilder().withVendorEncodingType(vendorEncodingType);
+
+        // Then: exception is thrown
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testInvalidVendorListVersion() {
+        // Given: invalid vendor list version - 50
+        int vendorListVersion = -50;
+
+        // When: trying to build using invalid value
+        final VendorConsent vendorConsent = new VendorConsentBuilder()
+                .withConsentRecordCreatedOn(now)
+                .withConsentRecordLastUpdatedOn(now)
+                .withConsentLanguage("EN")
+                .withVendorListVersion(vendorListVersion)
+                .build();
+
+        // Then: exception is thrown
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testInvalidMaxVendorId() {
+        // Given: invalid max vendor ID = -1
+        int maxVendorId = -1;
+
+        // When: trying to build using invalid value
+        final VendorConsent vendorConsent = new VendorConsentBuilder()
+                .withConsentRecordCreatedOn(now)
+                .withConsentRecordLastUpdatedOn(now)
+                .withConsentLanguage("EN")
+                .withVendorListVersion(10)
+                .withMaxVendorId(maxVendorId)
+                .build();
+
+        // Then: exception is thrown
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testInvalidRangeEntry() {
+        // Given: max vendor ID of 300;
+        int maxVendorId = 300;
+
+        // And: list of range entries with values that are > max vendor ID
+        final List<RangeEntry> rangeEntries = Arrays.asList(
+                new SingleRangeEntry(1),
+                new StartEndRangeEntry(100,400)
+        );
+
+        // When: trying to build using invalid value
+        final VendorConsent vendorConsent = new VendorConsentBuilder()
+                .withConsentRecordCreatedOn(now)
+                .withConsentRecordLastUpdatedOn(now)
+                .withConsentLanguage("EN")
+                .withVendorListVersion(10)
+                .withMaxVendorId(maxVendorId)
+                .withVendorEncodingType(1)
+                .withRangeEntries(rangeEntries)
+                .build();
+
+        // Then: exception is thrown
+    }
+
+    @Test
+    public void testValidBidFieldEncoding() {
+        // Given: set of consent string parameters
+        final Set<Integer> allowedPurposes = new HashSet<>(Arrays.asList(1, 2, 3, 24));
+        final int cmpId = 1;
+        final int cmpVersion = 1;
+        final int consentScreenID = 1;
+        final String consentLanguage = "EN";
+        final int vendorListVersion = 10;
+        final int maxVendorId = 180;
+        final int vendorEncodingType = 0; // Bit field
+        final Set<Integer> allowedVendors = new HashSet<>(Arrays.asList(1, 10, 180));
+
+        // When: vendor consent is build
+        final VendorConsent vendorConsent = new VendorConsentBuilder()
+                .withConsentRecordCreatedOn(now)
+                .withConsentRecordLastUpdatedOn(now)
+                .withCmpID(cmpId)
+                .withCmpVersion(cmpVersion)
+                .withConsentScreenID(consentScreenID)
+                .withConsentLanguage(consentLanguage)
+                .withVendorListVersion(vendorListVersion)
+                .withAllowedPurposes(allowedPurposes)
+                .withMaxVendorId(maxVendorId)
+                .withVendorEncodingType(vendorEncodingType)
+                .withBitField(allowedVendors)
+                .build();
+
+
+        // Then: values in vendor consent match parameters
+        assertThat(vendorConsent.getVersion(),is(1));
+        assertThat(vendorConsent.getConsentRecordCreated(),is(now));
+        assertThat(vendorConsent.getConsentRecordLastUpdated(),is(now));
+        assertThat(vendorConsent.getCmpId(),is(cmpId));
+        assertThat(vendorConsent.getCmpVersion(),is(cmpVersion));
+        assertThat(vendorConsent.getConsentScreen(),is(consentScreenID));
+        assertThat(vendorConsent.getVendorListVersion(),is(vendorListVersion));
+        assertThat(vendorConsent.getAllowedPurposes(),is(allowedPurposes));
+        assertThat(vendorConsent.getMaxVendorId(),is(maxVendorId));
+
+        assertTrue(vendorConsent.isPurposeAllowed(1));
+        assertTrue(vendorConsent.isPurposeAllowed(2));
+        assertTrue(vendorConsent.isPurposeAllowed(3));
+        assertTrue(vendorConsent.isPurposeAllowed(24));
+
+        assertTrue(vendorConsent.isVendorAllowed(1));
+        assertTrue(vendorConsent.isVendorAllowed(10));
+        assertTrue(vendorConsent.isVendorAllowed(180));
+
+        assertFalse(vendorConsent.isPurposeAllowed(4));
+        assertFalse(vendorConsent.isPurposeAllowed(5));
+
+        assertFalse(vendorConsent.isVendorAllowed(5));
+        assertFalse(vendorConsent.isVendorAllowed(11));
+        assertFalse(vendorConsent.isVendorAllowed(179));
+    }
+
+    @Test
+    public void testValidRangedEncoding() {
+        // Given: set of consent string parameters
+        final Set<Integer> allowedPurposes = new HashSet<>(Arrays.asList(1, 2, 3, 4, 5));
+        final int cmpId = 10;
+        final int cmpVersion = 3;
+        final int consentScreenID = 4;
+        final String consentLanguage = "FR";
+        final int vendorListVersion = 231;
+        final int maxVendorId = 400;
+        final int vendorEncodingType = 1; // Bit field
+        final List<RangeEntry> rangeEntries = Arrays.asList(
+                new SingleRangeEntry(10),
+                new StartEndRangeEntry(100,200),
+                new SingleRangeEntry(350)
+        );
+
+        // When: vendor consent is build
+        final VendorConsent vendorConsent = new VendorConsentBuilder()
+                .withConsentRecordCreatedOn(now)
+                .withConsentRecordLastUpdatedOn(now)
+                .withCmpID(cmpId)
+                .withCmpVersion(cmpVersion)
+                .withConsentScreenID(consentScreenID)
+                .withConsentLanguage(consentLanguage)
+                .withVendorListVersion(vendorListVersion)
+                .withAllowedPurposes(allowedPurposes)
+                .withMaxVendorId(maxVendorId)
+                .withVendorEncodingType(vendorEncodingType)
+                .withDefaultConsent(false)
+                .withRangeEntries(rangeEntries)
+                .build();
+
+
+        // Then: values in vendor consent match parameters
+        assertThat(vendorConsent.getVersion(),is(1));
+        assertThat(vendorConsent.getConsentRecordCreated(),is(now));
+        assertThat(vendorConsent.getConsentRecordLastUpdated(),is(now));
+        assertThat(vendorConsent.getCmpId(),is(cmpId));
+        assertThat(vendorConsent.getCmpVersion(),is(cmpVersion));
+        assertThat(vendorConsent.getConsentScreen(),is(consentScreenID));
+        assertThat(vendorConsent.getVendorListVersion(),is(vendorListVersion));
+        assertThat(vendorConsent.getAllowedPurposes(),is(allowedPurposes));
+        assertThat(vendorConsent.getMaxVendorId(),is(maxVendorId));
+
+        assertTrue(vendorConsent.isPurposeAllowed(1));
+        assertTrue(vendorConsent.isPurposeAllowed(2));
+        assertTrue(vendorConsent.isPurposeAllowed(3));
+        assertTrue(vendorConsent.isPurposeAllowed(4));
+        assertTrue(vendorConsent.isPurposeAllowed(5));
+
+        assertTrue(vendorConsent.isVendorAllowed(10));
+        assertTrue(vendorConsent.isVendorAllowed(150));
+        assertTrue(vendorConsent.isVendorAllowed(350));
+
+        assertFalse(vendorConsent.isVendorAllowed(50));
+        assertFalse(vendorConsent.isVendorAllowed(240));
+    }
+}

--- a/src/test/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilderTest.java
+++ b/src/test/java/com/iab/gdpr/consent/implementation/v1/VendorConsentBuilderTest.java
@@ -1,5 +1,6 @@
 package com.iab.gdpr.consent.implementation.v1;
 
+import com.iab.gdpr.Purpose;
 import com.iab.gdpr.consent.range.RangeEntry;
 import com.iab.gdpr.consent.range.SingleRangeEntry;
 import com.iab.gdpr.consent.range.StartEndRangeEntry;
@@ -15,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.iab.gdpr.Purpose.*;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -35,7 +37,7 @@ public class VendorConsentBuilderTest {
         final Set<Integer> allowedPurposes = new HashSet<>(Arrays.asList(1, 2, 3, 99));
 
         // When: passing set to the builder
-        new VendorConsentBuilder().withAllowedPurposes(allowedPurposes);
+        new VendorConsentBuilder().withAllowedPurposeIds(allowedPurposes);
 
         // Then: exception is thrown
     }
@@ -131,7 +133,7 @@ public class VendorConsentBuilderTest {
                 .withConsentScreenID(consentScreenID)
                 .withConsentLanguage(consentLanguage)
                 .withVendorListVersion(vendorListVersion)
-                .withAllowedPurposes(allowedPurposes)
+                .withAllowedPurposeIds(allowedPurposes)
                 .withMaxVendorId(maxVendorId)
                 .withVendorEncodingType(vendorEncodingType)
                 .withBitField(allowedVendors)
@@ -146,7 +148,7 @@ public class VendorConsentBuilderTest {
         assertThat(vendorConsent.getCmpVersion(),is(cmpVersion));
         assertThat(vendorConsent.getConsentScreen(),is(consentScreenID));
         assertThat(vendorConsent.getVendorListVersion(),is(vendorListVersion));
-        assertThat(vendorConsent.getAllowedPurposes(),is(allowedPurposes));
+        assertThat(vendorConsent.getAllowedPurposeIds(),is(allowedPurposes));
         assertThat(vendorConsent.getMaxVendorId(),is(maxVendorId));
 
         assertTrue(vendorConsent.isPurposeAllowed(1));
@@ -169,7 +171,7 @@ public class VendorConsentBuilderTest {
     @Test
     public void testValidRangedEncoding() {
         // Given: set of consent string parameters
-        final Set<Integer> allowedPurposes = new HashSet<>(Arrays.asList(1, 2, 3, 4, 5));
+        final Set<Purpose> allowedPurposes = new HashSet<>(Arrays.asList(STORAGE_AND_ACCESS, PERSONALIZATION, AD_SELECTION, CONTENT_DELIVERY, MEASUREMENT));
         final int cmpId = 10;
         final int cmpVersion = 3;
         final int consentScreenID = 4;
@@ -211,11 +213,11 @@ public class VendorConsentBuilderTest {
         assertThat(vendorConsent.getAllowedPurposes(),is(allowedPurposes));
         assertThat(vendorConsent.getMaxVendorId(),is(maxVendorId));
 
-        assertTrue(vendorConsent.isPurposeAllowed(1));
-        assertTrue(vendorConsent.isPurposeAllowed(2));
-        assertTrue(vendorConsent.isPurposeAllowed(3));
-        assertTrue(vendorConsent.isPurposeAllowed(4));
-        assertTrue(vendorConsent.isPurposeAllowed(5));
+        assertTrue(vendorConsent.isPurposeAllowed(STORAGE_AND_ACCESS));
+        assertTrue(vendorConsent.isPurposeAllowed(PERSONALIZATION));
+        assertTrue(vendorConsent.isPurposeAllowed(AD_SELECTION));
+        assertTrue(vendorConsent.isPurposeAllowed(CONTENT_DELIVERY));
+        assertTrue(vendorConsent.isPurposeAllowed(MEASUREMENT));
 
         assertTrue(vendorConsent.isVendorAllowed(10));
         assertTrue(vendorConsent.isVendorAllowed(150));

--- a/src/test/java/com/iab/gdpr/util/Utils.java
+++ b/src/test/java/com/iab/gdpr/util/Utils.java
@@ -1,0 +1,28 @@
+package com.iab.gdpr.util;
+
+import com.iab.gdpr.Bits;
+
+/**
+ * Testing utility functions
+ */
+public class Utils {
+
+    /**
+     * Create bit buffer from string representation
+     * @param binaryString binary string
+     * @return bit buffer
+     */
+    public static Bits fromBinaryString(String binaryString) {
+        final int length = binaryString.length();
+        final boolean bitsFit = (length % 8) == 0;
+        final Bits bits = new Bits(new byte[length / 8 + (bitsFit ? 0 : 1)]);
+
+        for (int i = 0; i < length; i++)
+            if (binaryString.charAt(i) == '1')
+                bits.setBit(i);
+            else
+                bits.unsetBit(i);
+
+        return bits;
+    }
+}


### PR DESCRIPTION
Following changes are made in this refactor:

1. Vendor consent encoding, decoding and representation concerns are separated. VendorConsent is now an interface that classes that represent vendor consent should implement.
1. Added class VendorConsentDecoder that inspects version number in consent string. Even though there is only version 1 at this moment, this can be used to easily add support for new version without breaking API contract. 
1. Added class v1.ByteBufferBackedVendorConsent that implements VendorConsent
1. Added class v1.VendorConsentBuilder to help build vendor consent.
1. Added class VendorConsentEncoder that encodes vendor consent to Base64 string
1. Bumped version to 2.0.0

TODO:
1. Add Contributing doc documenting git branching
1. Setup CI 
1. Setup release and publish processes

Also done:
1. Created release/1 branch to track version 1.x changes 