### PR TITLE
support publishing to a remote maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,19 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        credentials {
+            username "$mavenUser"
+            password "$mavenPassword"
+        }
+        url "$mavenUrl"
+    }
 }
 
 group = 'com.iab.gdpr'
@@ -20,4 +29,28 @@ dependencies {
             "junit:junit:4.11",
             "org.hamcrest:java-hamcrest:2.0.0.0"
     )
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            artifact sourceJar
+        }
+    }
+    repositories {
+        maven {
+            credentials {
+                username "$mavenUser"
+                password "$mavenPassword"
+            }
+            url "$mavenPublishUrl"
+        }
+    }
+}
+
+task sourceJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allJava
 }


### PR DESCRIPTION
This library is not published to maven central repo yet. This p/r adds ability to publish it into a company owned maven repo to share it with other members of a team.

Maven repo URLs, user and password should be defined in `~/.gradle/gradle.properties`

```
mavenUrl=https://nexus.company.com/repository/aggregate
mavenPublishUrl=https://nexus.company.com/repository/snapshots
mavenUser=user1
mavenPassword=victory
```

By running the command bellow you can publish it into your maven repo.
```
./gradlew publish
```

Let me know if anything is missing or needs improvement. Thanks!