### PR TITLE
Optimize isPurposeAllowed() to just check the bit instead of creating…

### DIFF
--- a/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
+++ b/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
@@ -100,8 +100,8 @@ public class ByteBufferBackedVendorConsent implements VendorConsent {
 
     @Override
     public boolean isPurposeAllowed(int purposeId) {
-        if (purposeId < 1) return false;
-        return getAllowedPurposeIds().contains(purposeId);
+        if (purposeId < 1 || purposeId > PURPOSES_SIZE) return false;
+        return bits.getBit(PURPOSES_OFFSET + purposeId - 1);
     }
 
     @Override


### PR DESCRIPTION
… the waste set every time