### PR TITLE
Fix isVendorAllowed() for zero vendor ID

### DIFF
--- a/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
+++ b/src/main/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsent.java
@@ -112,7 +112,7 @@ public class ByteBufferBackedVendorConsent implements VendorConsent {
     @Override
     public boolean isVendorAllowed(int vendorId) {
         final int maxVendorId = getMaxVendorId();
-        if (vendorId < 0 || vendorId > maxVendorId) return false;
+        if (vendorId < 1 || vendorId > maxVendorId) return false;
 
         if (encodingType() == VENDOR_ENCODING_RANGE) {
             final boolean defaultConsent = bits.getBit(DEFAULT_CONSENT_OFFSET);

--- a/src/test/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsentTest.java
+++ b/src/test/java/com/iab/gdpr/consent/implementation/v1/ByteBufferBackedVendorConsentTest.java
@@ -237,6 +237,14 @@ public class ByteBufferBackedVendorConsentTest {
         assertFalse(vendorConsent.isVendorAllowed(3));
         assertFalse(vendorConsent.isVendorAllowed(31));
         assertFalse(vendorConsent.isVendorAllowed(32));
+
+        // Vendors outside range [1, MaxVendorId] are not allowed
+        assertFalse(vendorConsent.isVendorAllowed(-99));
+        assertFalse(vendorConsent.isVendorAllowed(-1));
+        assertFalse(vendorConsent.isVendorAllowed(0));
+        assertFalse(vendorConsent.isVendorAllowed(33));
+        assertFalse(vendorConsent.isVendorAllowed(34));
+        assertFalse(vendorConsent.isVendorAllowed(99));
     }
 
     @Test
@@ -275,6 +283,14 @@ public class ByteBufferBackedVendorConsentTest {
         assertFalse(vendorConsent.isVendorAllowed(28));
         assertFalse(vendorConsent.isVendorAllowed(31));
         assertFalse(vendorConsent.isVendorAllowed(32));
+
+        // Vendors outside range [1, MaxVendorId] are not allowed
+        assertFalse(vendorConsent.isVendorAllowed(-99));
+        assertFalse(vendorConsent.isVendorAllowed(-1));
+        assertFalse(vendorConsent.isVendorAllowed(0));
+        assertFalse(vendorConsent.isVendorAllowed(33));
+        assertFalse(vendorConsent.isVendorAllowed(34));
+        assertFalse(vendorConsent.isVendorAllowed(99));
     }
 
     @Test
@@ -313,6 +329,14 @@ public class ByteBufferBackedVendorConsentTest {
         assertTrue(vendorConsent.isVendorAllowed(15));
         assertTrue(vendorConsent.isVendorAllowed(31));
         assertTrue(vendorConsent.isVendorAllowed(32));
+
+        // Vendors outside range [1, MaxVendorId] are not allowed
+        assertFalse(vendorConsent.isVendorAllowed(-99));
+        assertFalse(vendorConsent.isVendorAllowed(-1));
+        assertFalse(vendorConsent.isVendorAllowed(0));
+        assertFalse(vendorConsent.isVendorAllowed(33));
+        assertFalse(vendorConsent.isVendorAllowed(34));
+        assertFalse(vendorConsent.isVendorAllowed(99));
     }
 
     @Test(expected = VendorConsentParseException.class)


### PR DESCRIPTION
The [spec](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-) states that the range of valid vendor IDs spans from 1 to MaxVendorID.
However, `isVendorAllowed` can sometimes return `true` for zero vendor ID because it does not reject it before further analysis of consent string bits.
This pull request fixes that bug and provided respective unit tests.