### PR TITLE
Add VendorConsent.getAllowedVendorIds()

### DIFF
--- a/src/main/java/com/iab/gdpr/consent/VendorConsent.java
+++ b/src/main/java/com/iab/gdpr/consent/VendorConsent.java
@@ -81,6 +81,12 @@ public interface VendorConsent {
 
     /**
      *
+     * @return the set of allowed vendor id's which are permitted according to this consent string
+     */
+    Set<Integer> getAllowedVendorIds();
+
+    /**
+     *
      * @return the maximum VendorId for which consent values are given.
      */
     int getMaxVendorId();


### PR DESCRIPTION
The interface `VendorConsent` does not currently define the method `getAllowedVendorIds`. I feel this is missing in comparison to [the JavaScript implentation](https://github.com/InteractiveAdvertisingBureau/Consent-String-SDK-JS/blob/61ca7515c433111a3aa618053bc32eb7608d7349/src/consent-string.js#L376).

I am adding this method and its implementation in `ByteBufferBackedVendorConsent`, along with updating the relevant JUnit tests.

This addresses #42.